### PR TITLE
Add download attribute and dynamic filename

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <input class="form-control" type="file" id="logFile" accept=".html">
     </div>
     <button class="btn btn-primary" id="fixBtn">修正</button>
-    <a class="btn btn-success ms-2 d-none" id="downloadBtn">ダウンロード</a>
+    <a class="btn btn-success ms-2 d-none" id="downloadBtn" download>ダウンロード</a>
   </div>
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -347,7 +347,9 @@ function handleFix() {
     const blob = new Blob([outputHTML], { type: "text/html" });
     const url = URL.createObjectURL(blob);
     const dl = document.getElementById("downloadBtn");
+    const filename = file.name.replace(/\.html?$/, '') + '_fixed.html';
     dl.href = url;
+    dl.download = filename;
     dl.classList.remove("d-none");
   };
   reader.readAsText(file);


### PR DESCRIPTION
## Summary
- allow proper download by adding `download` attribute to the download link
- create a download filename inside `handleFix()`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878a43153dc832fa78ed84fda107144