### PR TITLE
feat: parse arithmetic expressions without dice

### DIFF
--- a/script.js
+++ b/script.js
@@ -266,7 +266,26 @@ function parseLog(text) {
   function flattenDiceOutcome(expr) {
     // (1) ベースのダイス式を取得
     const diceExp = expr.querySelector(".p-exp__dice-exp");
-    if (!diceExp) return {};
+    if (!diceExp) {
+      // ダイス式が無い場合はそのまま数式として処理
+      const nodes = Array.from(
+        expr.querySelectorAll(".p-exp__number, .p-exp__operator")
+      );
+      let formula = "";
+      let result = "";
+      for (let i = 0; i < nodes.length; i++) {
+        const text = nodes[i].textContent.trim();
+        if (text === "=") {
+          const next = nodes[i + 1];
+          if (next && next.classList.contains("p-exp__number")) {
+            result = next.textContent.trim();
+          }
+          break;
+        }
+        formula += text;
+      }
+      return formula && result ? { formula, result } : {};
+    }
     const nums = diceExp.querySelectorAll(".p-exp__number");
     const dOpEl = diceExp.querySelector(".p-exp__operator");
     const dOp = dOpEl ? dOpEl.textContent.trim() : "";


### PR DESCRIPTION
## Summary
- handle expressions lacking `.p-exp__dice-exp` by scanning numbers and operators
- return `{ formula, result }` from non-dice expressions so outputs include simple calculations

## Testing
- `node` script exercising `flattenDiceOutcome` with "80 × 8 = 640" mock nodes -> `80×8=640`


------
https://chatgpt.com/codex/tasks/task_e_688f4f5e69a0832fb4568df88181813e