### PR TITLE
Add cache-control meta tags to generated output

### DIFF
--- a/script.js
+++ b/script.js
@@ -249,7 +249,14 @@ let outputHTML = "";
 
 function buildOutput(doc) {
   const out = document.implementation.createHTMLDocument(doc.title);
-  out.head.innerHTML = `<meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>${doc.title}</title><style>${style1}</style><style>${style2}</style>`;
+  out.head.innerHTML = `<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="0">
+<title>${doc.title}</title>
+<style>${style1}</style>
+<style>${style2}</style>`;
   const body = out.body;
   body.innerHTML = `<label for="toggle" id="label_toggle">表示/非表示</label><input type="checkbox" id="toggle"><header><label>▽ 非表示にするタブ</label><label for="main"><input type="checkbox" onclick="Hide(this)" id="main">発言</label><label for="zatsudan"><input type="checkbox" onclick="Hide(this)" id="zatsudan">ノーマル</label></header><div class="wrapper"><h1>${doc.title}</h1><h2>セッション開始</h2></div><footer></footer><script>${hideScript}</script>`;
   return out;


### PR DESCRIPTION
## Summary
- prevent caching of generated HTML by embedding cache-control meta tags

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f58139e78832f8e65b1984c083514